### PR TITLE
Fix compilation of the benchmarks + Docker

### DIFF
--- a/benchmark/WriterBench.hs
+++ b/benchmark/WriterBench.hs
@@ -3,14 +3,26 @@
 module WriterBench (benchmarks) where
 
 import           Criterion
+import           Data.String              (IsString (..))
 import           Network.HTTP.Link.Types
 import           Network.HTTP.Link.Writer
+import           Network.URI
+
+instance IsString URI where
+    fromString str = case parseURI str of
+        Just uri -> uri
+        Nothing -> error $ "Failed to parse URI: " ++ str
 
 benchmarks :: [Benchmark]
 benchmarks = [
-    bench "minimal" $ whnf writeLinkHeader [Link "http://example.com/thing" [(Rel, "next")]]
-  , bench "large" $ whnf writeLinkHeader [ Link "http://example.com/something long" [ (Rel, "next prev http://hello.world/undefined")
-                                                                                    , (Title, "this is a test benchmark thingy")]
-                                         , Link "https://use.tls.everywhere.pls" [ (Rel, "license")
-                                                                                 , (Rev, "author") ]]
+    bench "minimal" $ whnf writeLinkHeader
+        [ Link "http://example.com/thing" [ (Rel, "next") ] ]
+  , bench "large" $ whnf writeLinkHeader
+        [ Link "http://example.com/something_long"
+               [ (Rel, "next prev http://hello.world/undefined")
+               , (Title, "this is a test benchmark thingy")
+               ]
+        , Link "https://use.tls.everywhere.pls"
+               [ (Rel, "license")
+               , (Rev, "author") ]]
   ]

--- a/http-link-header.cabal
+++ b/http-link-header.cabal
@@ -63,6 +63,7 @@ benchmark benchmarks
       , text
       , http-link-header
       , directory
+      , network-uri
       , transformers
       , criterion
     default-language: Haskell2010


### PR DESCRIPTION
Maybe at some point there was an `IsString` instance for `URI`. There doesn't
seem to be one anymore. I added a hacky one to make benchmarks run.

This also adds some Dockerfiles for easier debugging across different GHC
versions. You should add CI with https://github.com/hvr/multi-ghc-travis