### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/http-link-header.cabal
+++ b/http-link-header.cabal
@@ -69,4 +69,6 @@ benchmark benchmarks
     default-language: Haskell2010
     hs-source-dirs: benchmark
     main-is: Bench.hs
+    other-modules: ParserBench
+                   WriterBench
     type: exitcode-stdio-1.0


### PR DESCRIPTION
Currently, the benchmarks fail to compile when obtained from Hackage since the `ParserBench` and `WriterBench` modules aren't distributed with the tarball. This PR adds them explicitly to the `.cabal` file.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065