### PR TITLE
removed dependency on bytestring-conversion

### DIFF
--- a/http-link-header.cabal
+++ b/http-link-header.cabal
@@ -29,7 +29,6 @@ library
       , network-uri
       , http-api-data
       , attoparsec
-      , bytestring-conversion
     default-language: Haskell2010
     exposed-modules:
         Network.HTTP.Link

--- a/library/Network/HTTP/Link.hs
+++ b/library/Network/HTTP/Link.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE Trustworthy, FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Trustworthy       #-}
 
 -- | This module exports all the things at the same time.
 module Network.HTTP.Link (
@@ -8,22 +9,16 @@ module Network.HTTP.Link (
 , module Network.HTTP.Link.Parser
 ) where
 
-import           Data.ByteString.Conversion
-import           Web.HttpApiData
+import           Data.Text.Encoding
+import safe      Network.HTTP.Link.Parser
 import safe      Network.HTTP.Link.Types
 import safe      Network.HTTP.Link.Writer
-import safe      Network.HTTP.Link.Parser
-
-instance ToByteString [Link] where
-  builder = builder . writeLinkHeader
-
-instance ToByteString Link where
-  builder = builder . writeLink
+import           Web.HttpApiData
 
 instance ToHttpApiData [Link] where
   toUrlPiece = toUrlPiece . writeLinkHeader
-  toHeader = toByteString'
+  toHeader = encodeUtf8 . writeLinkHeader
 
 instance ToHttpApiData Link where
   toUrlPiece = toUrlPiece . writeLink
-  toHeader = toByteString'
+  toHeader = encodeUtf8 . writeLink

--- a/library/Network/HTTP/Link.hs
+++ b/library/Network/HTTP/Link.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE Trustworthy       #-}
+{-# LANGUAGE Trustworthy, FlexibleInstances #-}
 
 -- | This module exports all the things at the same time.
 module Network.HTTP.Link (
@@ -9,11 +8,11 @@ module Network.HTTP.Link (
 , module Network.HTTP.Link.Parser
 ) where
 
+import           Web.HttpApiData
 import           Data.Text.Encoding
 import safe      Network.HTTP.Link.Parser
 import safe      Network.HTTP.Link.Types
 import safe      Network.HTTP.Link.Writer
-import           Web.HttpApiData
 
 instance ToHttpApiData [Link] where
   toUrlPiece = toUrlPiece . writeLinkHeader


### PR DESCRIPTION
Hi,
   I'm suggesting the elimination of the dependency on `bytestring-conversion`, by replacing the use of `Data.ByteString.Conversion.toByteString'` with `Data.Text.Encoding.encodeUtf8`, and using `encodeUtf8` directly in the ToHttpApiData Link and [Link] implementations, given that `writeLinkHeader` and  `writeLink` return Text, and  `Data.ByteString.Conversion.toByteString'`  appears to resolve to a call to `encodeUtf8 :: Text -> ByteString` for Text. This allows the elimination of the `ToByteString` implementations for `Link` and `[Link]`, which so far as I can tell are for internal use only. 

The dependency on `bytestring-conversion` happens to be causing a build problem for `stack --docker` with LTS-13.1. This fix solves that.  The dependency on text exists already. 

results of stack test suggest no problems:

```
http-link-header-1.0.3.1: test (suite: tests)
            
Progress 1/2: http-link-header-1.0.3.1
Network.HTTP.Link.Parser
  linkHeader
    parses a single link
    parses empty attributes
    parses custom attributes
    parses backslash escaped attributes
    parses escaped attributes
    parses multiple attributes
    parses custom attributes named similarly to standard ones
    parses unquoted rel, rev attributes
    does not blow up on title*
    parses weird whitespace all over the place
Network.HTTP.Link.Writer
  writeLinkHeader
    writes a single link
    writes params with quote escaping
    writes multiple parameters
    writes custom params
    writes multiple links
Network.HTTP.Link
  writeLinkHeader → parseLinkHeader
    roundtrips successfully
      +++ OK, passed 100 tests.

Finished in 2.5769 seconds
16 examples, 0 failures
                                      
http-link-header-1.0.3.1: Test suite tests passed
```

thanks,

Stephen.